### PR TITLE
Add flag marker for cdn and media mozilla domains

### DIFF
--- a/chartoptions.js
+++ b/chartoptions.js
@@ -68,14 +68,19 @@ var flags = {
   showInLegend: false,
   data: [
     {
-      x: Date.UTC(2014, 4, 23),
+      x: Date.UTC(2014, 4, 24),
       title: 'Twitter production',
       text: 'Twitter moved to production'
     },
     {
-      x: Date.UTC(2014, 4, 23),
+      x: Date.UTC(2014, 4, 24),
       title: 'Google root PEMs',
       text: 'Google switched to root PEMs'
+    },
+    {
+      x: Date.UTC(2014, 4, 29),
+      title: 'Mozilla cdn, media production',
+      text: 'Mozilla cdn, media production'
     }
   ]
 };

--- a/dashboard.js
+++ b/dashboard.js
@@ -39,8 +39,8 @@ function makeChart(version, measure) {
         var data = histogram.map(function(count, start, end, index) {
           return count;
         });
-        // Skip dates with fewer than 100 submissions
-        var minVolume = 100;
+        // Skip dates with fewer than 1000 submissions
+        var minVolume = 1000;
         if (data[0] + data[1] > minVolume) {
           // Failure = 0, success = 1
           date.setUTCHours(0);


### PR DESCRIPTION
@mozkeeler This is already pushed. Also I had the date for the other flag markers off by one. For some reason, in JS the month field is 0 indexed and everything else starts at 1.
