### PR TITLE
Work on #8

### DIFF
--- a/chartoptions.js
+++ b/chartoptions.js
@@ -83,6 +83,11 @@ var flags = {
       title: 'Mozilla cdn, media production',
       text: 'Mozilla cdn, media production'
     },
+    {
+      x: Date.UTC(2014, 5, 13),
+      title: 'Google production',
+      text: 'Google moved to production'
+    },
   ]
 };
 

--- a/chartoptions.js
+++ b/chartoptions.js
@@ -98,13 +98,13 @@ var moz_flags = {
   data: [
     {
       x: Date.UTC(2014, 5, 5),
-      title: 'Mozilla AMO production',
-      text: 'Mozilla AMO production'
+      title: 'AMO production',
+      text: 'AMO production'
     },
     {
       x: Date.UTC(2014, 5, 8),
-      title: 'Mozilla FxA test',
-      text: 'Mozilla FxA test'
+      title: 'FxA test',
+      text: 'FxA test'
     }
   ]
 };

--- a/dashboard.js
+++ b/dashboard.js
@@ -21,7 +21,8 @@ var hostIds = {
 };
 
 // Versions for which we have any data.
-var versions = [ "nightly/32", "nightly/33" ];
+var auroraVersions = [ "aurora/32" ];
+var nightlyVersions = [ "nightly/32", "nightly/33" ];
 
 // Minimum volume for which to display data
 var minVolume = 1000;
@@ -32,18 +33,8 @@ var versionedMeasures = [];
 // Set up our series
 var tsSeries = {};
 var volumeSeries = {};
-Object.keys(requiredMeasures).forEach(function(m) {
-  tsSeries[requiredMeasures[m]] = [];
-  volumeSeries[requiredMeasures[m]] = [];
-});
-
 var hostRates = [];
 var hostVolume = [];
-Object.keys(hostIds).forEach(function(host) {
-  hostRates[hostIds[host].series] = [];
-  hostVolume[hostIds[host].series] = [];
-});
-
 // Setup our highcharts on document-ready.
 $(document).ready(function() {
   tsChart = new Highcharts.StockChart(tsOptions);
@@ -61,10 +52,23 @@ function print(line) {
 Telemetry.init(function() {
   // For nightly versions, we only have one release per date, so we can
   // construct a single graph for all versions of nightly.
-  makeTimeseries();
-  makeHostCharts();
+  makeGraphsForChannel(nightlyVersions);
 });
 
+function makeGraphsForChannel(versions) {
+  Object.keys(requiredMeasures).forEach(function(m) {
+    tsSeries[requiredMeasures[m]] = [];
+    volumeSeries[requiredMeasures[m]] = [];
+  });
+
+  Object.keys(hostIds).forEach(function(host) {
+    hostRates[hostIds[host].series] = [];
+    hostVolume[hostIds[host].series] = [];
+  });
+
+  makeTimeseries(versions);
+  makeHostCharts(versions);
+}
 // Sort [date, {rate|volume}] pairs based on the date
 function sortByDate(p1, p2)
 {
@@ -73,7 +77,7 @@ function sortByDate(p1, p2)
 
 // Returns a promise that resolves when all of the versions for all of the
 // required measures have been stuffed into the timeseries.
-function makeTimeseries()
+function makeTimeseries(versions)
 {
   // construct a single graph for all versions of nightly
   var promises = [];
@@ -148,7 +152,7 @@ function makeTimeseriesForMeasure(version, measure) {
   return p;
 }
 
-function makeHostCharts() {
+function makeHostCharts(versions) {
   var promises = [];
   hostMeasures.forEach(function(m) {
     versions.forEach(function(v) {

--- a/dashboard.js
+++ b/dashboard.js
@@ -52,18 +52,15 @@ function print(line) {
 };
 
 function changeView(channel) {
+  // Unselect the old channel
+  document.querySelector("#" + currentChannel)
+      .setAttribute("style", "background-color:white");
   currentChannel = channel;
   makeGraphsForChannel(currentChannel);
-  // Toggle selector. The highlighted button uses the same green color as
+  // Select the new channel. The highlighted button uses the same green color as
   // Highcharts.
   document.querySelector("#" + currentChannel)
     .setAttribute("style", "background-color:#90ed7d");
-  Object.keys(channels).forEach(function(channel) {
-    if (channel != currentChannel) {
-      document.querySelector("#" + channel)
-        .setAttribute("style", "background-color:white");
-    }
-  });
 }
 
 // Initialize telemetry.js
@@ -153,9 +150,6 @@ function makeTimeseriesForMeasure(version, measure) {
           // Failure = 0, success = 1
           if (data[0] + data[1] > minVolume) {
             date.setUTCHours(0);
-            //print("Measure: " + measure + " version: " + version +
-            //      " Date: " + date.toString() + " total: " +
-            //      (data[0] + data[1]) + " violations: " + data[0]);
             tsSeries[index].push([date.getTime(),
                                   data[0] / (data[0] + data[1])]);
             volumeSeries[index].push([date.getTime(),

--- a/dashboard.js
+++ b/dashboard.js
@@ -21,8 +21,11 @@ var hostIds = {
 };
 
 // Versions for which we have any data.
-var auroraVersions = [ "aurora/32" ];
-var nightlyVersions = [ "nightly/32", "nightly/33" ];
+var channels = {
+  nightly: [ "nightly/32", "nightly/33" ],
+  aurora: [ "aurora/32" ]
+};
+var currentChannel = "nightly";
 
 // Minimum volume for which to display data
 var minVolume = 1000;
@@ -48,14 +51,29 @@ function print(line) {
   document.querySelector('#output').textContent += line + "\n";
 };
 
+function changeView(channel) {
+  currentChannel = channel;
+  makeGraphsForChannel(currentChannel);
+  // Toggle selector. The highlighted button uses the same green color as
+  // Highcharts.
+  document.querySelector("#" + currentChannel)
+    .setAttribute("style", "background-color:#90ed7d");
+  Object.keys(channels).forEach(function(channel) {
+    if (channel != currentChannel) {
+      document.querySelector("#" + channel)
+        .setAttribute("style", "background-color:white");
+    }
+  });
+}
+
 // Initialize telemetry.js
 Telemetry.init(function() {
   // For nightly versions, we only have one release per date, so we can
   // construct a single graph for all versions of nightly.
-  makeGraphsForChannel(nightlyVersions);
+  changeView("nightly");
 });
 
-function makeGraphsForChannel(versions) {
+function makeGraphsForChannel(channel) {
   Object.keys(requiredMeasures).forEach(function(m) {
     tsSeries[requiredMeasures[m]] = [];
     volumeSeries[requiredMeasures[m]] = [];
@@ -66,8 +84,8 @@ function makeGraphsForChannel(versions) {
     hostVolume[hostIds[host].series] = [];
   });
 
-  makeTimeseries(versions);
-  makeHostCharts(versions);
+  makeTimeseries(channels[channel]);
+  makeHostCharts(channels[channel]);
 }
 // Sort [date, {rate|volume}] pairs based on the date
 function sortByDate(p1, p2)

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <title>Public Key Pinning Dashboard</title>
 <center>
-<button onclick="makeGraphsForChannel(nightlyVersions)">Nightly</button>
-<button onclick="makeGraphsForChannel(auroraVersions)">Aurora</button>
+<button id=nightly onclick="changeView('nightly')">Nightly</button>
+<button id=aurora onclick="changeView('aurora')">Aurora</button>
 </center>
 <head>
 <script src="http://telemetry.mozilla.org/v1/telemetry.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,8 @@
 <title>Public Key Pinning Dashboard</title>
+<center>
+<button onclick="makeGraphsForChannel(nightlyVersions)">Nightly</button>
+<button onclick="makeGraphsForChannel(auroraVersions)">Aurora</button>
+</center>
 <head>
 <script src="http://telemetry.mozilla.org/v1/telemetry.js"></script>
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <title>Public Key Pinning Dashboard</title>
 <center>
-<button id=nightly onclick="changeView('nightly')">Nightly</button>
-<button id=aurora onclick="changeView('aurora')">Aurora</button>
+<button id=nightly style="background-color:white" onclick="changeView('nightly')">Nightly</button>
+<button id=aurora style="background-color:white" onclick="changeView('aurora')">Aurora</button>
 </center>
 <head>
 <script src="http://telemetry.mozilla.org/v1/telemetry.js"></script>


### PR DESCRIPTION
Support Nightly 32 and 33 as a single graph. I think the easiest way to support other channels is to have a little "Nightly/Aurora" selector at the top of the page, since for any given channel there won't be more than one version per build-date.
