### PR TITLE
Fix #17

### DIFF
--- a/chartoptions.js
+++ b/chartoptions.js
@@ -137,6 +137,11 @@ var moz_flags = {
       x: Date.UTC(2014, 5, 8),
       title: 'FxA test',
       text: 'FxA test'
+    },
+    {
+      x: Date.UTC(2014, 6, 3),
+      title: 'api.FxA test',
+      text: 'api.FxA test'
     }
   ]
 };
@@ -243,6 +248,7 @@ var hostOptions = {
     { name: 'addons.mozilla.org (prod)' },
     { name: 'aus4.mozilla.org (test)' },
     { name: 'accounts.firefox.com (test)' },
+    { name: 'api.accounts.firefox.com (test)' },
     moz_flags
   ]
 };
@@ -272,6 +278,7 @@ var hostVolumeOptions = {
     { name: 'addons.mozilla.org (prod)' },
     { name: 'aus4.mozilla.org (test)' },
     { name: 'accounts.firefox.com (test)' },
+    { name: 'api.accounts.firefox.com (test)' },
     moz_flags
   ]
 };

--- a/chartoptions.js
+++ b/chartoptions.js
@@ -150,11 +150,13 @@ $(function() {
     title: {
       x: -20 //center
     },
+/*
     xAxis: {
       type: 'datetime',
       minTickInterval: 24 * 3600 * 1000,
       min: minDate.getTime()
     },
+*/
     yAxis: {
       min: 0
     },

--- a/chartoptions.js
+++ b/chartoptions.js
@@ -103,6 +103,16 @@ var flag_data = {
       title: '*.twitter.com (test)',
       text: '*.twitter.com (test)'
     },
+    {
+      x: Date.UTC(2014, 6, 8),
+      title: '*.twitter.com (prod)',
+      text: '*.twitter.com (prod)'
+    },
+    {
+      x: Date.UTC(2014, 6, 8),
+      title: 'dropbox (test)',
+      text: 'dropbox (test)'
+    },
   ],
   aurora: [
     {

--- a/chartoptions.js
+++ b/chartoptions.js
@@ -150,13 +150,12 @@ $(function() {
     title: {
       x: -20 //center
     },
-/*
     xAxis: {
       type: 'datetime',
       minTickInterval: 24 * 3600 * 1000,
-      min: minDate.getTime()
+      // Why is this breaking?
+      // min: minDate.getTime()
     },
-*/
     yAxis: {
       min: 0
     },

--- a/dashboard.js
+++ b/dashboard.js
@@ -18,6 +18,7 @@ var hostIds = {
   "addons.mozilla.org (prod)": { bucket: 1, series: 1 },
   "aus4.mozilla.org (test)": { bucket: 3, series: 2 },
   "accounts.firefox.com (test)": { bucket: 4, series: 3 },
+  "api.accounts.firefox.com (test)": { bucket: 5, series: 4 },
 };
 
 // Versions for which we have any data.
@@ -253,11 +254,11 @@ function filterEvolution(measure, histogramEvolution) {
       if (data[index] && (data[index] + data[index + 1] > 0)) {
         rate = data[index] / (data[index] + data[index + 1]);
       }
-      if (data[index] + data[index + 1] > minVolume) {
-        hostRates[hostIds[host].series].push([date.getTime(), rate]);
-        hostVolume[hostIds[host].series].push([date.getTime(),
-                                           data[index] + data[index + 1]]);
-      }
+      // Don't filter on minVolume for mozilla hosts, because some hosts like
+      // FxA don't get very much traffic.
+      hostRates[hostIds[host].series].push([date.getTime(), rate]);
+      hostVolume[hostIds[host].series].push([date.getTime(),
+                                             data[index] + data[index + 1]]);
     });
   });
 }

--- a/dashboard.js
+++ b/dashboard.js
@@ -29,7 +29,7 @@ var channels = {
 var currentChannel = "nightly";
 
 // Minimum volume for which to display data
-var minVolume = 1000;
+var minVolume = 1200;
 
 // Array of [[version, measure]] for requesting loadEvolutionOverBuilds.
 var versionedMeasures = [];
@@ -94,7 +94,7 @@ function sortByDate(p1, p2)
 // Filter duplicate dates to account for screwed up telemetry data
 function filterDuplicateDates(series)
 {
-  // Work on a copy
+  // Work on a copy so we don't cause side-effects without realizing.
   var s = series;
 
   // Series is an array of pairs [[date, volume]]. If successive dates have the
@@ -176,7 +176,7 @@ function makeTimeseriesForMeasure(version, measure) {
           var data = histogram.map(function(count, start, end, index) {
             return count;
           });
-          // Skip dates with fewer than 1000 submissions
+          // Skip dates with fewer than minVolume submissions
           // Failure = 0, success = 1
           if (data[0] + data[1] > minVolume) {
             date.setUTCHours(0);


### PR DESCRIPTION
Fixes error by getting rid of mindate (?!). I don't totally understand it, but it seems to work.

Also filter duplicate dates where Telemetry is reporting multiple counts for the same day.
